### PR TITLE
 Modify for current class names and assign appropriate priorities 

### DIFF
--- a/remove-workflow-states.php
+++ b/remove-workflow-states.php
@@ -11,19 +11,19 @@ License: GPL2
 
 
 function wpdr_remove_workflow_init_hooks() {
-	if ( !class_exists( 'Document_Revisions' ) )
+	if ( !class_exists( 'WP_Document_Revisions' ) )
 		return;
 
-	$wpdr = Document_Revisions::$instance;
+	$wpdr = WP_Document_Revisions::$instance;
 	remove_action( 'admin_init', array( &$wpdr, 'initialize_workflow_states' ) );
-	remove_action( 'init', array( &$wpdr, 'register_ct' ) );
+	remove_action( 'init', array( &$wpdr, 'register_ct' ), 15 );
 }
 
 function wpdr_remove_workflow_admin_hooks() {
-	if ( !class_exists( 'Document_Revisions' ) )
+	if ( !class_exists( 'WP_Document_Revisions_Admin' ) )
 		return;
 
-	$wpdra = Document_Revisions::$instance->admin;
+	$wpdra = WP_Document_Revisions_Admin::$instance->admin;
 	remove_filter( 'manage_edit-document_columns', array( &$wpdra, 'add_workflow_state_column' ) );
 	remove_action( 'manage_document_posts_custom_column', array( &$wpdra, 'workflow_state_column_cb' ) );
 	remove_action( 'save_post', array( &$wpdra, 'workflow_state_save' ) );
@@ -34,6 +34,6 @@ function wpdr_remove_workflow_metabox() {
 	remove_meta_box('workflow-state', 'document','side');
 }
 
-add_action( 'plugins_loaded', 'wpdr_remove_workflow_init_hooks' );
-add_action( 'admin_init', 'wpdr_remove_workflow_admin_hooks', 0);
+add_action( 'plugins_loaded', 'wpdr_remove_workflow_init_hooks', 99 );
+add_action( 'admin_init', 'wpdr_remove_workflow_admin_hooks', 99 );
 add_action( 'document_edit', 'wpdr_remove_workflow_metabox' );

--- a/remove-workflow-states.php
+++ b/remove-workflow-states.php
@@ -23,7 +23,7 @@ function wpdr_remove_workflow_admin_hooks() {
 	if ( !class_exists( 'WP_Document_Revisions_Admin' ) )
 		return;
 
-	$wpdra = WP_Document_Revisions_Admin::$instance->admin;
+	$wpdra = WP_Document_Revisions_Admin::$instance;
 	remove_filter( 'manage_edit-document_columns', array( &$wpdra, 'add_workflow_state_column' ) );
 	remove_action( 'manage_document_posts_custom_column', array( &$wpdra, 'workflow_state_column_cb' ) );
 	remove_action( 'save_post', array( &$wpdra, 'workflow_state_save' ) );


### PR DESCRIPTION
Loaded the existing and found that various small modifications were needed to make it work; namely
- Use the current class names
- Set a priority so that the removal event occurs after the add event.

Note. I think the issue referred to in previous Pull request (#2) was that the remove sub-menu action had a default priority higher than the add sub-menu action. 