### PR TITLE
Modify for filter name change in WP Document Revisions

### DIFF
--- a/remove-workflow-states.php
+++ b/remove-workflow-states.php
@@ -24,7 +24,7 @@ function wpdr_remove_workflow_admin_hooks() {
 		return;
 
 	$wpdra = WP_Document_Revisions_Admin::$instance;
-	remove_filter( 'manage_edit-document_columns', array( &$wpdra, 'add_workflow_state_column' ) );
+	remove_filter( 'manage_document_posts_columns', array( &$wpdra, 'add_workflow_state_column' ) );
 	remove_action( 'manage_document_posts_custom_column', array( &$wpdra, 'workflow_state_column_cb' ) );
 	remove_action( 'save_post', array( &$wpdra, 'workflow_state_save' ) );
 


### PR DESCRIPTION
Column name filter used to add column is now manage_document_posts_columns in WP Document Revisions so need to remove it from that filter here.

[Sorry for omission in previous Pull Request. Need to review my process.]